### PR TITLE
Update site.conf to work with recent gluon

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -11,24 +11,30 @@
 	regdom = 'DE',
 
 	wifi24 = {
-		ssid = '061-FREIFUNK-',
+		ap = {
+		    ssid = '061-FREIFUNK-',
+		},
 		channel = 1,
-		htmode = 'HT40',
-		mesh_ssid = '02:ca:ff:ee:ba:be',
-		mesh_bssid = '02:ca:ff:ee:ba:be',
-		mesh_mcast_rate = 12000,
-		mesh_mtu = 1532,
-		mesh_vlan = 61,
+		ibss = {
+		     ssid = '02:ca:ff:ee:ba:be',
+		     bssid = '02:ca:ff:ee:ba:be',
+		     mcast_rate = 12000,
+		     mtu = 1532,
+		     vlan = 61,
+		},
 	},
 	wifi5 = {
-		ssid = '061-FREIFUNK-',
+		ap = {
+		    ssid = '061-FREIFUNK-',
+		},
 		channel = 44,
-		htmode = 'HT20',
-		mesh_ssid = '02:44:ca:ff:ee:ee',
-		mesh_bssid = '02:44:ca:ff:ee:ee',
-		mesh_mcast_rate = 12000,
-		mesh_mtu = 1532,
-		mesh_vlan = 61,
+		ibss = {
+		     ssid = '02:44:ca:ff:ee:ee',
+		     bssid = '02:44:ca:ff:ee:ee',
+		     mcast_rate = 12000,
+		     mtu = 1532,
+		     vlan = 61,
+		},
 	},
 
 	next_node = {


### PR DESCRIPTION
The site.conf format changed, see
https://github.com/freifunk-gluon/gluon/blob/master/docs/releases/v2015.2.rst
I changed the wifi settings to work with the new layout. Attention: HT40
is not supported anymore!

I didn't have time yet to test it's mesh compatibility with nodes running the official gluon code yet. site.mk is still refering to v2015.1.2.
